### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ to make it easy to create a buildout environment within the project.
 Here we'll see the most common usages, and refer to [the full documentation for
 more details][doc].
 
-[doc]:https://buildstrap.readthedocs.org/
+[doc]:https://buildstrap.readthedocs.io/
 
 ## Usage
 
@@ -116,7 +116,7 @@ Yeah, I'm being evil here 😈
 
 You can have a look at the [sources documentation][srcdoc].
 
-[srcdoc]:http://buildstrap.readthedocs.io/en/latest/buildstrap.html
+[srcdoc]:https://buildstrap.readthedocs.io/en/latest/buildstrap.html
 
 ## Nota Bene
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
